### PR TITLE
Update GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,9 @@ jobs:
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: docs     # The folder the action should deploy.
-          token: ${{ secrets.GITHUB_TOKEN }} # Default GITHUB_TOKEN
+          token: ${{ secrets.ACCESS_TOKEN }} # Default GITHUB_TOKEN
           clean: true # Automatically remove deleted files from the deploy branch
           # Optional: if your project is not at the root of the user/org pages site
           # single-commit: true # Optional: if you want to squash new commits to a single commit
-          # target-folder: 'tourney-time' # If deploying to a subfolder on gh-pages branch
+          repository-name: duereg/duereg.github.io
+          target-folder: tourney-time # If deploying to a subfolder on gh-pages branch

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Access the online tool here: [Tourney Time UI](https://duereg.github.io/tourney-
 
 _(Note: This UI is built and deployed via GitHub Pages from the `docs/` directory of this repository.)_
 
+## Deployment to GitHub Pages
+
+For the GitHub Actions workflow to deploy the UI to the `duereg/duereg.github.io` repository, a Personal Access Token (PAT) with `repo` scope must be created. This token should be added as a secret named `ACCESS_TOKEN` in the GitHub repository settings where this workflow runs.
+
 ## Usage Example
 
 ```shell


### PR DESCRIPTION
This change modifies the GitHub Actions workflow to deploy the UI to the `duereg/duereg.github.io` repository in the `tourney-time` folder.

Key changes:
- Updated `.github/workflows/ci.yml`:
    - The `deploy-ui` job now uses `repository-name: duereg/duereg.github.io`.
    - The `deploy-ui` job now uses `target-folder: tourney-time`.
    - The deployment token is changed to `secrets.ACCESS_TOKEN` to allow cross-repository push.
- Updated `README.md`:
    - Added a section explaining the need to create a Personal Access Token (PAT) with `repo` scope and store it as `ACCESS_TOKEN` in repository secrets for the deployment to function correctly.