### PR TITLE
Fix: Update GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,10 +68,9 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4 # Using a popular action
         with:
-          branch: gh-pages # The branch the action should deploy to.
+          branch: master # The branch the action should deploy to.
           folder: docs     # The folder the action should deploy.
           token: ${{ secrets.ACCESS_TOKEN }} # Default GITHUB_TOKEN
-          clean: true # Automatically remove deleted files from the deploy branch
           # Optional: if your project is not at the root of the user/org pages site
           # single-commit: true # Optional: if you want to squash new commits to a single commit
           repository-name: duereg/duereg.github.io


### PR DESCRIPTION
Modifies the `deploy-ui` job in the CI/CD workflow to:
- Deploy to the `master` branch of the `duereg.github.io` repository instead of `gh-pages`.
- Stop cleaning the target branch before deployment. This ensures that existing content in the `duereg.github.io` repository is not deleted.

The deployment will now place the contents of the `docs` folder into the `tourney-time` subfolder on the `master` branch of `duereg.github.io`.