### PR TITLE
feat: Add combined schedule view and update headers

### DIFF
--- a/src/ui/components/ResultsDisplay.tsx
+++ b/src/ui/components/ResultsDisplay.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { TourneyTimeResult, Game, Schedule } from '@lib/tourney-time';
 import { formatTime } from '../utils/formatTime';
 
@@ -8,6 +8,8 @@ interface ResultsDisplayProps {
 }
 
 const ResultsDisplay: React.FC<ResultsDisplayProps> = ({ results, error }) => {
+  const [combineSchedules, setCombineSchedules] = useState(false);
+
   if (error) {
     return (
       <div
@@ -57,6 +59,7 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({ results, error }) => {
   const renderFullSchedule = (
     scheduleData: Game[] | Game[][],
     actualAreas: number, // New parameter: results.tourneySchedule.areas
+    combine: boolean,
   ) => {
     if (!scheduleData || scheduleData.length === 0) {
       return <p>No games in this schedule.</p>;
@@ -90,8 +93,8 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({ results, error }) => {
             <tr>
               <th style={thStyle}>Round</th>
               <th style={thStyle}>Game ID</th>
-              <th style={thStyle}>Team 1</th>
-              <th style={thStyle}>Team 2</th>
+              <th style={thStyle}>Team 1 (Black)</th>
+              <th style={thStyle}>Team 2 (White)</th>
             </tr>
           </thead>
           <tbody>
@@ -108,43 +111,130 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({ results, error }) => {
       );
     };
 
-    // Case 1: Single actual area or schedule is already flat (Game[])
-    if (actualAreas === 1 || !Array.isArray(scheduleData[0])) {
-      const games = (Array.isArray(scheduleData[0])
-        ? (scheduleData as Game[][]).flat() // Flatten if it's Game[][] but actualAreas is 1
-        : scheduleData) as Game[]; // Already Game[]
+    // Case 1: Single actual area, schedule is already flat (Game[]), or not combining
+    if (actualAreas === 1 || !Array.isArray(scheduleData[0]) || !combine) {
+      if (actualAreas > 1 && !combine) {
+        // Standard multi-area display (separate tables)
+        const scheduleByArea: Game[][] = Array.from({ length: actualAreas }, () => []);
+        const gameGroups = scheduleData as Game[][];
+
+        gameGroups.forEach((group) => {
+          group.forEach((game, gameIndexInGroup) => {
+            if (gameIndexInGroup < actualAreas) {
+              scheduleByArea[gameIndexInGroup].push(game);
+            }
+          });
+        });
+
+        return (
+          <div>
+            <h4>Full Game Schedule (Per Area):</h4>
+            {scheduleByArea.map((areaSchedule, areaIndex) => (
+              <div key={areaIndex} style={{ marginBottom: '20px' }}>
+                <h5>Schedule for Area {areaIndex + 1}</h5>
+                {renderTableForGames(areaSchedule, `Area ${areaIndex + 1}`)}
+              </div>
+            ))}
+          </div>
+        );
+      }
+
+      // Single area or already flat
+      const games = (Array.isArray(scheduleData[0]) && actualAreas === 1
+        ? (scheduleData as Game[][]).flat()
+        : Array.isArray(scheduleData[0]) && actualAreas > 1 && combine // This case should be handled by combined logic below, but as fallback
+        ? (scheduleData as Game[][]).flat() // Fallback flat
+        : scheduleData) as Game[];
 
       return (
         <div>
-          <h4>Full Game Schedule (Single Area):</h4>
+          <h4>Full Game Schedule {actualAreas === 1 ? '(Single Area)' : '(Combined View - Fallback)'}:</h4>
           {renderTableForGames(games)}
         </div>
       );
     }
 
-    // Case 2: Multiple actual areas (actualAreas > 1) and scheduleData is Game[][]
-    const scheduleByArea: Game[][] = Array.from({ length: actualAreas }, () => []);
-    const gameGroups = scheduleData as Game[][];
+    // Case 2: Multiple actual areas (actualAreas > 1) and scheduleData is Game[][] and combine is true
+    if (combine && actualAreas > 1 && Array.isArray(scheduleData) && scheduleData.length > 0 && Array.isArray(scheduleData[0])) {
+      const combinedGames: (Game & { area: number })[] = [];
+      const rounds = scheduleData as Game[][]; // Correctly typed as Game[RoundIndex][GameIndexInRound]
 
-    gameGroups.forEach((group) => {
-      group.forEach((game, gameIndexInGroup) => {
-        if (gameIndexInGroup < actualAreas) {
-          scheduleByArea[gameIndexInGroup].push(game);
-        }
+      // The schedule from the library is typically structured as:
+      // schedule = [ round1Games[], round2Games[], ... ]
+      // Each roundXGames[] contains games for that round, distributed across available areas.
+      // For example, if actualAreas = 2:
+      // round1Games = [gameForArea1, gameForArea2, gameForArea1_nextSlot, gameForArea2_nextSlot, ...]
+      // The `game.id` often contains area info, but we can also derive it.
+      // The crucial part is how games within a round are assigned to areas.
+      // The original per-area display logic iterated through gameGroups (rounds)
+      // then pushed game to scheduleByArea[gameIndexInGroup].push(game)
+      // This implies gameIndexInGroup was directly mapping to area, which means
+      // the library might produce schedule[Round][Area] directly or the old code was misinterpreting.
+
+      // Let's re-evaluate the structure provided by `results.schedule`.
+      // `results.schedule` is `Game[][]` when multiple.ts is used.
+      // `multiple.ts` has `schedule[roundCounter].push(game);`
+      // This means `scheduleData` is `Game[roundIndex][gameInRoundIndex]`
+      // The games *within* a round are already ordered by area by the generator.
+      // e.g. For 2 areas, round 1: [gameR1A1, gameR1A2, gameR1A1_2, gameR1A2_2, ...]
+      // So, gameInRoundIndex = 0 is Area 1, gameInRoundIndex = 1 is Area 2,
+      // gameInRoundIndex = 2 is Area 1 (next timeslot), gameInRoundIndex = 3 is Area 2 (next timeslot)
+
+      rounds.forEach((roundGames, roundIndex) => {
+        roundGames.forEach((game, gameIndexInRound) => {
+          const areaForThisGame = (gameIndexInRound % actualAreas) + 1;
+          combinedGames.push({
+            ...game,
+            round: game.round, // Ensure round from game data is used
+            area: areaForThisGame,
+          });
+        });
       });
-    });
 
-    return (
-      <div>
-        <h4>Full Game Schedule (Per Area):</h4>
-        {scheduleByArea.map((areaSchedule, areaIndex) => (
-          <div key={areaIndex} style={{ marginBottom: '20px' }}>
-            <h5>Schedule for Area {areaIndex + 1}</h5>
-            {renderTableForGames(areaSchedule, `Area ${areaIndex + 1}`)}
-          </div>
-        ))}
-      </div>
-    );
+      // Sort combinedGames by round, then by area to ensure correct interleaving for display
+      // The game object itself should have the correct 'round' property.
+      // The previous loop already processes games round by round, and within each round, by area index.
+      // So, additional sorting might be redundant if source data is already ordered, but good for safety.
+      combinedGames.sort((a, b) => {
+        if (a.round !== b.round) {
+          return a.round - b.round;
+        }
+        return a.area - b.area;
+      });
+
+      return (
+        <div>
+          <h4>Full Game Schedule (Combined View)</h4>
+          <table style={tableStyle}>
+            <thead>
+              <tr>
+                <th style={thStyle}>Round</th>
+                <th style={thStyle}>Area</th>
+                <th style={thStyle}>Game ID</th>
+                <th style={thStyle}>Team 1 (Black)</th>
+                <th style={thStyle}>Team 2 (White)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {combinedGames.map((game, index) => (
+                <tr key={`${game.id}-${index}`}>
+                  <td style={tdStyle}>{game.round}</td>
+                  <td style={tdStyle}>{game.area}</td>
+                  <td style={tdStyle}>{game.id}</td>
+                  <td style={tdStyle}>{game.teams[0]}</td>
+                  <td style={tdStyle}>{game.teams[1]}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      );
+    }
+
+    // Fallback or other conditions (already handled above if !combine or actualAreas === 1)
+    // This part should ideally not be reached if logic above is correct,
+    // but acts as a safety net.
+    return <p>Error in rendering schedule. Please check inputs.</p>;
   };
 
   return (
@@ -157,7 +247,21 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({ results, error }) => {
       {renderScheduleDetails(results.tourneySchedule, 'Tournament Schedule')}
       {renderScheduleDetails(results.playoffSchedule, 'Playoff Schedule')}
       <div style={sectionStyle}>
-        {renderFullSchedule(results.schedule, results.tourneySchedule.areas || 1)}
+        <div>
+          <label>
+            <input
+              type="checkbox"
+              checked={combineSchedules}
+              onChange={(e) => setCombineSchedules(e.target.checked)}
+            />
+            Combine schedules into one table
+          </label>
+        </div>
+        {renderFullSchedule(
+          results.schedule,
+          results.tourneySchedule.areas || 1,
+          combineSchedules,
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Implements a feature allowing users to view a combined schedule table for multiple playing areas.

Key changes:
- Added a checkbox in ResultsDisplay.tsx to toggle between individual per-area tables and a single combined table.
- The combined table includes an "Area" column and interleaves games by round, then by area.
- Updated table headers "Team 1" and "Team 2" to "Team 1 (Black)" and "Team 2 (White)" respectively.
- State for the toggle is managed within ResultsDisplay.tsx.
- Adjusted renderFullSchedule logic to accommodate the new view and data transformation for combined display.