### PR TITLE
Fix: Correct round display and add Game ID to Horizontal Combined View

### DIFF
--- a/src/ui/components/HorizontalCombinedView.tsx
+++ b/src/ui/components/HorizontalCombinedView.tsx
@@ -48,18 +48,40 @@ const transformScheduleToHorizontal = (
     const maxSlotsInRound = Math.max(...gamesByAreaInRound.map(areaGamesList => areaGamesList.length));
     if (maxSlotsInRound === 0) return;
 
+    // All games in gamesByAreaInRound for a given roundIndex share the same actual round number.
+    // We can pick the round number from the first game in the first non-empty area slot.
+    // Or, more simply, just use roundIndex + 1 as the base round for this visual block,
+    // as the input `schedule` is Game[roundIndex][gameIndexInRound].
+    // The key is that individual game objects `game.round` should be used if they accurately
+    // reflect the true round, especially if `scheduleBalancer` might change round numbers.
+    // For now, assuming `game.round` from the input `scheduleData` is the source of truth for each game.
+
     for (let slot = 0; slot < maxSlotsInRound; slot++) {
-      const row: Record<string, any> = { round: roundIndex + 1 };
+      // Initialize row with a common round number for this visual row.
+      // The round number displayed per row will be determined by the first game encountered in that row,
+      // or it can be set based on roundIndex if all games in this "horizontal slot" belong to the same logical round.
+      // Let's ensure the 'Round' column shows the round of the games in that row.
+      // We will determine the round for the row from the first available game in the slot.
+      let commonRoundForRow: number | string = '';
+
+      const row: Record<string, any> = {}; // gameId and team data will be added per area
+
       for (let areaIdx = 0; areaIdx < numAreas; areaIdx++) {
         const game = gamesByAreaInRound[areaIdx]?.[slot];
         if (game) {
+          if (commonRoundForRow === '') {
+            commonRoundForRow = game.round; // Set common round from the first game found in this slot
+          }
+          row[`area${areaIdx + 1}GameId`] = game.id;
           row[`area${areaIdx + 1}Team1`] = game.teams[0];
           row[`area${areaIdx + 1}Team2`] = game.teams[1];
         } else {
+          row[`area${areaIdx + 1}GameId`] = '';
           row[`area${areaIdx + 1}Team1`] = '';
           row[`area${areaIdx + 1}Team2`] = '';
         }
       }
+      row.round = commonRoundForRow !== '' ? commonRoundForRow : roundIndex + 1; // Fallback if no games in slot
       transformedRows.push(row);
     }
   });
@@ -83,6 +105,7 @@ const HorizontalCombinedView: React.FC<HorizontalCombinedViewProps> = ({
 
   const headers = ['Round'];
   for (let i = 1; i <= actualAreas; i++) {
+    headers.push(`Area ${i}: Game ID`);
     headers.push(`Area ${i}: Team 1 (Black)`);
     headers.push(`Area ${i}: Team 2 (White)`);
   }
@@ -103,6 +126,7 @@ const HorizontalCombinedView: React.FC<HorizontalCombinedViewProps> = ({
                 <td style={tdStyle}>{row.round}</td>
                 {Array.from({ length: actualAreas }).map((_, areaIndex) => (
                   <React.Fragment key={`hcell-area-${areaIndex}`}>
+                    <td style={tdStyle}>{row[`area${areaIndex + 1}GameId`]}</td>
                     <td style={tdStyle}>{row[`area${areaIndex + 1}Team1`]}</td>
                     <td style={tdStyle}>{row[`area${areaIndex + 1}Team2`]}</td>
                   </React.Fragment>


### PR DESCRIPTION
- Modified `transformScheduleToHorizontal` to ensure the 'Round' column accurately reflects the game's actual round, not the visual slot index.
- Added 'Game ID' sub-columns for each area in the Horizontal Combined View.
- Updated data transformation and table rendering to include and display game IDs.